### PR TITLE
fix issue #17 Handle unsecaped > in attribute

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -776,6 +776,17 @@ export default function Parser(options) {
         if (j === -1) {
           return handleError('unclosed tag');
         }
+        // search for the next tag opener
+        const nextTagOpener = xml.indexOf('<', j + 1);
+        if (nextTagOpener === -1) {
+          // if there is no next tag opener
+          // search for the last tag closer in the document
+          j = xml.lastIndexOf('>');
+        } else {
+          // if the next tag opener exists
+          // search for the tag closer nearest to and at before the next tag opener
+          j = xml.lastIndexOf('>', nextTagOpener);
+        }
 
         if (onAttention) {
           onAttention(xml.substring(i, j + 1), decodeEntities, getContext);
@@ -809,6 +820,17 @@ export default function Parser(options) {
 
       if (j == -1) {
         return handleError('unclosed tag');
+      }
+      // search for the next tag opener
+      const nextTagOpener = xml.indexOf('<', j + 1);
+      if (nextTagOpener === -1) {
+        // if there is no next tag opener
+        // search for the last tag closer in the document
+        j = xml.lastIndexOf('>');
+      } else {
+        // if the next tag opener exists
+        // search for the tag closer nearest to and at before the next tag opener
+        j = xml.lastIndexOf('>', nextTagOpener);
       }
 
       // don't process attributes;

--- a/test/elements.js
+++ b/test/elements.js
@@ -1257,3 +1257,52 @@ test({
     ['closeTag', 'ns0:root']
   ],
 });
+
+// Should not throw with '>' in attribute value of regular  element (#17)
+test({
+  xml: '<doc><element id="sample>error"></element></doc>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['openTag', 'element', { id: 'sample>error' }, false],
+    ['closeTag', 'element', false],
+    ['closeTag', 'doc', false],
+  ],
+});
+
+// Should not throw with '>' in attribute value of self-closing element (#17)
+test({
+  xml: '<doc><element id="sample>error" /></doc>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['openTag', 'element', { id: 'sample>error' }, true],
+    ['closeTag', 'element', true],
+    ['closeTag', 'doc', false],
+  ],
+});
+
+// Should not throw with '>' in attribute value of self-closing element at the end of the document
+test({
+  xml: '<doc></doc><element id="sample>error" />',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['closeTag', 'doc', false],
+    ['openTag', 'element', { id: 'sample>error' }, true],
+    ['closeTag', 'element', true],
+  ],
+});
+
+// Should not throw with '>' in attribute value of self-closing element at the end of the document
+test({
+  xml: '<doc></doc><!-- !>>> --><element id="sample>error" />',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['closeTag', 'doc', false],
+    ['comment', ' !>>> '],
+    ['openTag', 'element', { id: 'sample>error' }, true],
+    ['closeTag', 'element', true],
+  ]
+});


### PR DESCRIPTION
We are using bpmn-moddle(https://github.com/bpmn-io/bpmn-moddle) and have encountered a similar problem to the one in the title.
I've written the modified code and would appreciate a review.
Specifically, the following rules were added when retrieving the end of a tag.
・If the next tag (including CDATA and Comment) exists -> get the tag closer ('>') just before the next tag.
・If the following tag does not exist -> get the last tag closer ('>')

We have also confirmed that the pull request from Mr. LukasHechenberger has been successfully retrieved and terminated. (We've also added our own test codes.)
https://github.com/nikku/saxen/pull/19