### PR TITLE
The content of an element can also contain a tag terminator ('>'), even if the CDATA, COMMENT or PI sections are not used.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -783,19 +783,27 @@ export default function Parser(options) {
           continue;
         }
 
-        j = xml.indexOf('>', i + 1);
-        if (j === -1) {
-          return handleError('unclosed tag');
-        }
+        for (x = i + 1; ; x++) {
+          const tmpw = xml.charCodeAt(x);
+          if (isNaN(tmpw)) {
+            j = -1;
+            return handleError('unclosed tag');
+          }
 
-        // search for the last '>' before the '<' or the document end
-        // to close this tag. this allows us to safely parse '>' in
-        // attribute names, e.g. <foo name="bar>1" />
-        x = xml.indexOf('<', j + 1);
-        if (x === -1) {
-          j = xml.lastIndexOf('>');
-        } else {
-          j = xml.lastIndexOf('>', x);
+          // [10] AttValue ::= '"' ([^<&"] | Reference)* '"' | "'" ([^<&'] | Reference)* "'"
+          // skips the quoted string
+          // (double quotes) does not appear in a literal enclosed by (double quotes)
+          // (single quote) does not appear in a literal enclosed by (single quote)
+          if (tmpw === 34) { //  '"'
+            const tmpi = xml.indexOf('"', x + 1);
+            x = tmpi !== -1 ? tmpi : x;
+          } else if (tmpw === 39) { // "'"
+            const tmpi = xml.indexOf("'", x + 1);
+            x = tmpi !== -1 ? tmpi : x;
+          } else if (tmpw === 62) { // '>'
+            j = x;
+            break;
+          }
         }
 
         if (onAttention) {
@@ -826,19 +834,27 @@ export default function Parser(options) {
         continue;
       }
 
-      j = xml.indexOf('>', i + 1);
-      if (j == -1) {
-        return handleError('unclosed tag');
-      }
+      for (x = i + 1; ; x++) {
+        const tmpw = xml.charCodeAt(x);
+        if (isNaN(tmpw)) {
+          j = -1;
+          return handleError('unclosed tag');
+        }
 
-      // search for the last '>' before the '<' or the document end
-      // to close this tag. this allows us to safely parse '>' in
-      // attribute names, e.g. <foo name="bar>1" />
-      x = xml.indexOf('<', j + 1);
-      if (x === -1) {
-        j = xml.lastIndexOf('>');
-      } else {
-        j = xml.lastIndexOf('>', x);
+        // [10] AttValue ::= '"' ([^<&"] | Reference)* '"' | "'" ([^<&'] | Reference)* "'"
+        // skips the quoted string
+        // (double quotes) does not appear in a literal enclosed by (double quotes)
+        // (single quote) does not appear in a literal enclosed by (single quote)
+        if (tmpw === 34) { //  '"'
+          const tmpi = xml.indexOf('"', x + 1);
+          x = tmpi !== -1 ? tmpi : x;
+        } else if (tmpw === 39) { // "'"
+          const tmpi = xml.indexOf("'", x + 1);
+          x = tmpi !== -1 ? tmpi : x;
+        } else if (tmpw === 62) { // '>'
+          j = x;
+          break;
+        }
       }
 
       // don't process attributes;

--- a/test/elements.js
+++ b/test/elements.js
@@ -1289,10 +1289,10 @@ test({
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['warn', 'illegal attribute name char'],
-    ['openTag', 'element', { bar: 'BAR' }],
-    ['closeTag', 'element'],
-    ['closeTag', 'doc'],
+    ['warn', 'missing attribute value quotes'],
+    ['openTag', 'element', {}, false],
+    ['text', 'o="FOO" bar="BAR" />'],
+    ['error', 'closing tag mismatch'],
   ],
 });
 
@@ -1302,12 +1302,9 @@ test({
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['warn', 'illegal first char attribute name'],
-    ['warn', 'illegal attribute name char'],
-    ['warn', 'missing attribute value'],
-    ['openTag', 'element', { foo: 'FOO', bar: 'BAR' }],
-    ['closeTag', 'element'],
-    ['closeTag', 'doc'],
+    ['openTag', 'element', { foo: 'FOO'}, false],
+    ['text', '> bar="BAR" />'],
+    ['error', 'closing tag mismatch']
   ],
 });
 
@@ -1318,10 +1315,9 @@ test({
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['warn', 'illegal character after attribute end'],
-    ['openTag', 'element', { bar: 'BAR' }],
-    ['closeTag', 'element'],
-    ['closeTag', 'doc'],
+    ['openTag', 'element', { foo: 'FOO' }, false],
+    ['text', ' bar="BAR" />'],
+    ['error', 'closing tag mismatch']
   ],
 });
 
@@ -1331,11 +1327,10 @@ test({
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['warn', 'illegal first char attribute name'],
-    ['warn', 'illegal attribute name char'],
-    ['warn', 'missing attribute value quotes'],
-    ['openTag', 'element', {}, false],
-    ['error', 'closing tag mismatch']
+    ['openTag', 'element', {}, true],
+    ['closeTag', 'element', true],
+    ['text', '>'],
+    ['closeTag', 'doc', false]
   ],
 });
 
@@ -1345,7 +1340,9 @@ test({
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['error', 'invalid nodeName']
+    ['openTag', 'element', {}, false],
+    ['text', '/>'],
+    ['error', 'closing tag mismatch']
   ],
 });
 
@@ -1420,4 +1417,28 @@ test({
     ['openTag', 'element', { id: 'sample>error' }, true],
     ['closeTag', 'element', true],
   ]
+});
+
+// should handle > in content
+test({
+  xml: '<doc><element foo=\'FO"O\'> bar="BAR" /></doc>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['openTag', 'element', { foo: 'FO"O' }, false],
+    ['text', ' bar="BAR" />'],
+    ['error', 'closing tag mismatch']
+  ],
+});
+
+// should handle > in content
+test({
+  xml: '<doc><element foo="FO\'O"> bar="BAR" /></doc>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['openTag', 'element', { foo: "FO'O" }, false],
+    ['text', ' bar="BAR" />'],
+    ['error', 'closing tag mismatch']
+  ],
 });

--- a/test/elements.js
+++ b/test/elements.js
@@ -1421,11 +1421,11 @@ test({
 
 // should handle > in content
 test({
-  xml: '<doc><element foo=\'FO"O\'> bar="BAR" /></element></doc>',
+  xml: '<doc><element foo="FO\'O"> bar="BAR" /></element></doc>',
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['openTag', 'element', { foo: 'FO"O' }, false],
+    ['openTag', 'element', { foo: 'FO\'O' }, false],
     ['text', ' bar="BAR" />'],
     ['closeTag', 'element', false],
     ['closeTag', 'doc', false]
@@ -1500,6 +1500,28 @@ test({
 });
 
 test({
+  xml: '<doc><!-- foo=\'FO"O\' --> bar="BAR" ></doc>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['comment', ' foo=\'FO"O\' '],
+    ['text', ' bar="BAR" >'],
+    ['closeTag', 'doc', false]
+  ],
+});
+
+test({
+  xml: '<doc><element foo="FOO>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['warn', 'missing closing quotes'],
+    ['openTag', 'element', {}, false],
+    ['error', 'unexpected end of file']
+  ],
+});
+
+test({
   xml: '<doc><element foo=\'FOO>',
   ns: true,
   expect: [
@@ -1511,12 +1533,11 @@ test({
 });
 
 test({
-  xml: '<doc><element foo="FOO>',
+  xml: '<doc><!-- element foo="FOO -->',
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['warn', 'missing closing quotes'],
-    ['openTag', 'element', {}, false],
+    ['comment', ' element foo="FOO '],
     ['error', 'unexpected end of file']
   ],
 });
@@ -1533,6 +1554,15 @@ test({
 
 test({
   xml: '<doc><!-- element foo="FOO>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['error', 'unclosed comment']
+  ],
+});
+
+test({
+  xml: '<doc><!-- element foo=\'FOO>',
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],

--- a/test/elements.js
+++ b/test/elements.js
@@ -1489,22 +1489,22 @@ test({
 });
 
 test({
-  xml: '<doc><!-- foo="FO\'O" --> bar="BAR" ></doc>',
+  xml: '<doc><! foo="FO\'O" > bar="BAR" ></doc>',
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['comment', ' foo="FO\'O" '],
+    ['attention', '<! foo="FO\'O" >'],
     ['text', ' bar="BAR" >'],
     ['closeTag', 'doc', false]
   ],
 });
 
 test({
-  xml: '<doc><!-- foo=\'FO"O\' --> bar="BAR" ></doc>',
+  xml: '<doc><! foo=\'FO"O\' > bar="BAR" ></doc>',
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['comment', ' foo=\'FO"O\' '],
+    ['attention', '<! foo=\'FO"O\' >'],
     ['text', ' bar="BAR" >'],
     ['closeTag', 'doc', false]
   ],
@@ -1533,39 +1533,22 @@ test({
 });
 
 test({
-  xml: '<doc><!-- element foo="FOO -->',
+  xml: '<doc><! element foo="FOO >',
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['comment', ' element foo="FOO '],
+    ['attention', '<! element foo="FOO >'],
     ['error', 'unexpected end of file']
   ],
 });
 
 test({
-  xml: '<doc><!-- element foo=\'FOO -->',
+  xml: '<doc><! element foo=\'FOO >',
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['comment', ' element foo=\'FOO '],
+    ['attention', '<! element foo=\'FOO >'],
     ['error', 'unexpected end of file']
   ],
 });
 
-test({
-  xml: '<doc><!-- element foo="FOO>',
-  ns: true,
-  expect: [
-    ['openTag', 'doc', {}, false],
-    ['error', 'unclosed comment']
-  ],
-});
-
-test({
-  xml: '<doc><!-- element foo=\'FOO>',
-  ns: true,
-  expect: [
-    ['openTag', 'doc', {}, false],
-    ['error', 'unclosed comment']
-  ],
-});

--- a/test/elements.js
+++ b/test/elements.js
@@ -1421,6 +1421,41 @@ test({
 
 // should handle > in content
 test({
+  xml: '<doc><element foo=\'FO"O\'> bar="BAR" /></element></doc>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['openTag', 'element', { foo: 'FO"O' }, false],
+    ['text', ' bar="BAR" />'],
+    ['closeTag', 'element', false],
+    ['closeTag', 'doc', false]
+  ],
+});
+
+test({
+  xml: '<doc><element foo=\'FO"O\'> bar="BAR" /></element></doc>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['openTag', 'element', { foo: 'FO"O' }, false],
+    ['text', ' bar="BAR" />'],
+    ['closeTag', 'element', false],
+    ['closeTag', 'doc', false]
+  ],
+});
+
+test({
+  xml: '<doc><element foo="FO\'O"> bar="BAR" /></doc>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['openTag', 'element', { foo: "FO'O" }, false],
+    ['text', ' bar="BAR" />'],
+    ['error', 'closing tag mismatch']
+  ],
+});
+
+test({
   xml: '<doc><element foo=\'FO"O\'> bar="BAR" /></doc>',
   ns: true,
   expect: [
@@ -1443,6 +1478,28 @@ test({
 });
 
 test({
+  xml: '<doc><!-- foo=\'FO"O\' --> bar="BAR" ></doc>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['comment', ' foo=\'FO"O\' '],
+    ['text', ' bar="BAR" >'],
+    ['closeTag', 'doc', false]
+  ],
+});
+
+test({
+  xml: '<doc><!-- foo="FO\'O" --> bar="BAR" ></doc>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['comment', ' foo="FO\'O" '],
+    ['text', ' bar="BAR" >'],
+    ['closeTag', 'doc', false]
+  ],
+});
+
+test({
   xml: '<doc><element foo=\'FOO>',
   ns: true,
   expect: [
@@ -1461,5 +1518,24 @@ test({
     ['warn', 'missing closing quotes'],
     ['openTag', 'element', {}, false],
     ['error', 'unexpected end of file']
+  ],
+});
+
+test({
+  xml: '<doc><!-- element foo=\'FOO -->',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['comment', ' element foo=\'FOO '],
+    ['error', 'unexpected end of file']
+  ],
+});
+
+test({
+  xml: '<doc><!-- element foo="FOO>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['error', 'unclosed comment']
   ],
 });

--- a/test/elements.js
+++ b/test/elements.js
@@ -1302,7 +1302,7 @@ test({
   ns: true,
   expect: [
     ['openTag', 'doc', {}, false],
-    ['openTag', 'element', { foo: 'FOO'}, false],
+    ['openTag', 'element', { foo: 'FOO' }, false],
     ['text', '> bar="BAR" />'],
     ['error', 'closing tag mismatch']
   ],

--- a/test/elements.js
+++ b/test/elements.js
@@ -1431,7 +1431,6 @@ test({
   ],
 });
 
-// should handle > in content
 test({
   xml: '<doc><element foo="FO\'O"> bar="BAR" /></doc>',
   ns: true,
@@ -1440,5 +1439,27 @@ test({
     ['openTag', 'element', { foo: "FO'O" }, false],
     ['text', ' bar="BAR" />'],
     ['error', 'closing tag mismatch']
+  ],
+});
+
+test({
+  xml: '<doc><element foo=\'FOO>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['warn', 'missing closing quotes'],
+    ['openTag', 'element', {}, false],
+    ['error', 'unexpected end of file']
+  ],
+});
+
+test({
+  xml: '<doc><element foo="FOO>',
+  ns: true,
+  expect: [
+    ['openTag', 'doc', {}, false],
+    ['warn', 'missing closing quotes'],
+    ['openTag', 'element', {}, false],
+    ['error', 'unexpected end of file']
   ],
 });


### PR DESCRIPTION
The content of an element can also contain a tag terminator ('>'), even if the CDATA, COMMENT or PI sections are not used. (Tag starters ('<') cannot be included.)

Citation.
https://www.w3.org/TR/xml/#NT-content
> [43] content ::= CharData? ((element | Reference | CDSect | PI | Comment) CharData?)*
> [14] CharData  ::=  [^<&]* - ([^<&]* ']]>' [^<&]*)

From the above, the following was the correct XML format. (I'm sorry.)
(I've also verified it using this site ( https://www.w3schools.com/xml/xml_validator.asp ))

```
<x some="・・>・・" any='・・"・・>・・'>・・・(A string that does not contain '<', but can contain '>'.)・・>・・</x>
```

So, I rethought the logic for getting the tag endings as follows.

・When retrieving the tag endpoint ('>') of a tag containing the current cursor, **read the current cursor position one character at a time** and use the following rules to find the tag endpoint ('>') while skipping the character string.

1. When the character the cursor points to matches "(double quotes), jump the cursor to the next "(double quotes).†1†3
2. When the character the cursor points to matches a '(single quote), jump the cursor to the next '(single quote).†2†3
3. If the character pointed by the cursor matches '>', it is treated as the end of the tag.

†1 " (double quotes) does not appear in a string enclosed in "(double quotes).
†2 ' (single quote) does not appear in a string enclosed in ' (single quote).
†3 If the corresponding symbol does not exist, the error is handled in the same way as before.

In considering the above logic, the following definitions were taken into account.

・The BNF of the start tag (STAG) (tag name, Attribute and blank (S) can only be included in the start tag)

Citation.
https://www.w3.org/TR/xml/#sec-starttags
> [40] STag ::= '<' Name (S Attribute)* S? '>' [WFC: Unique Att Spec]

EmptyElemTag, as well as the start tag (STAG)
> [44] EmptyElemTag ::= '<' Name (S Attribute)* S? '/>'  [WFC: Unique Att Spec]

The BNF of Attribute
> [41] Attribute ::= Name Eq AttValue  [VC: Attribute Value Type] [WFC: No External Entity References] [WFC: No < in Attribute Values]

The BNF of AttValue
> [10] AttValue ::= '"' ([^<&"] | Reference)* '"' | "'" ([^<&'] | Reference)* "'"
> [66] CharRef ::= '&#' [0-9]+ ';' | '&#x' [0-9a-fA-F]+ ';' [WFC: Legal Character]
> [67] Reference ::= EntityRef | CharRef
> [68] EntityRef ::= '&' Name ';' [WFC: Entity Declared] [VC: Entity Declared] [WFC: Parsed Entity] [WFC: No Recursion]

I also modified the test code assumptions and added test items.
We would appreciate it if you would consider incorporating the above considerations.
