### PR TITLE
Remove `xsi` special treatment

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,9 +1,5 @@
 import decodeEntities from './decode';
 
-var XSI_URI = 'http://www.w3.org/2001/XMLSchema-instance';
-var XSI_PREFIX = 'xsi';
-var XSI_TYPE = 'xsi:type';
-
 var NON_WHITESPACE_OUTSIDE_ROOT_NODE = 'non-whitespace outside of root node';
 
 function error(msg) {
@@ -213,9 +209,6 @@ export default function Parser(options) {
     for (k in nsMap) {
       _nsUriToPrefix[k] = nsMap[k];
     }
-
-    // FORCE default mapping for schema instance
-    _nsUriToPrefix[XSI_URI] = XSI_PREFIX;
 
     isNamespace = true;
     nsUriToPrefix = _nsUriToPrefix;
@@ -540,23 +533,6 @@ export default function Parser(options) {
 
         // end: normalize ns attribute name
 
-        // normalize xsi:type ns attribute value
-        if (name === XSI_TYPE) {
-          w = value.indexOf(':');
-
-          if (w !== -1) {
-            nsName = value.substring(0, w);
-
-            // handle default prefixes, i.e. xs:String gracefully
-            nsName = nsMatrix[nsName] || nsName;
-            value = nsName + value.substring(w);
-          } else {
-            value = defaultAlias + ':' + value;
-          }
-        }
-
-        // end: normalize xsi:type ns attribute value
-
         attrs[name] = value;
       }
 
@@ -585,23 +561,6 @@ export default function Parser(options) {
               : nsName + name.substr(w);
 
             // end: normalize ns attribute name
-
-            // normalize xsi:type ns attribute value
-            if (name === XSI_TYPE) {
-              w = value.indexOf(':');
-
-              if (w !== -1) {
-                nsName = value.substring(0, w);
-
-                // handle default prefixes, i.e. xs:String gracefully
-                nsName = nsMatrix[nsName] || nsName;
-                value = nsName + value.substring(w);
-              } else {
-                value = defaultAlias + ':' + value;
-              }
-            }
-
-            // end: normalize xsi:type ns attribute value
           }
 
           attrs[name] = value;

--- a/test/elements.js
+++ b/test/elements.js
@@ -1007,19 +1007,43 @@ test({
   ],
 });
 
-// normalize xsi:type
+// NOT normalize xsi:type
 test({
   xml: (
     '<foo xmlns="http://foo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Foo" />'
   ),
   ns: true,
   expect: [
-    [ 'openTag', 'ns0:foo', { 'xsi:type': 'ns0:Foo' } ],
+    [ 'openTag', 'ns0:foo', { 'xsi:type': 'Foo' } ],
     [ 'closeTag', 'ns0:foo' ],
   ],
 });
 
-// normalize prefixed xsi:type
+// NOT remap xsi:type
+test({
+  xml: (
+    '<foo xmlns="http://foo" xmlns:o="http://www.w3.org/2001/XMLSchema-instance" o:type="Foo" />'
+  ),
+  ns: true,
+  expect: [
+    [ 'openTag', 'ns0:foo', { 'o:type': 'Foo' } ],
+    [ 'closeTag', 'ns0:foo' ],
+  ],
+});
+
+// NOT normalize xsi:type
+test({
+  xml: (
+    '<foo xmlns="http://foo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Foo" />'
+  ),
+  ns: true,
+  expect: [
+    [ 'openTag', 'ns0:foo', { 'xsi:type': 'Foo' } ],
+    [ 'closeTag', 'ns0:foo' ],
+  ],
+});
+
+// NOT normalize prefixed xsi:type
 test({
   xml: (
     '<foo xmlns="http://foo" xmlns:bar="http://bar" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bar:Bar" />'
@@ -1031,7 +1055,7 @@ test({
   ],
 });
 
-// normalize xsi:type / preserve unknown prefix in value
+// NOT normalize xsi:type / preserve unknown prefix in value
 test({
   xml: (
     '<foo xmlns="http://foo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string" />'
@@ -1043,7 +1067,7 @@ test({
   ],
 });
 
-// normalize nested xsi:type
+// NOT normalize nested xsi:type
 test({
   xml: (
     '<foo xmlns="http://foo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
@@ -1053,7 +1077,7 @@ test({
   ns: true,
   expect: [
     [ 'openTag', 'ns0:foo' ],
-    [ 'openTag', 'ns0:bar', { 'xsi:type': 'ns0:Bar' } ],
+    [ 'openTag', 'ns0:bar', { 'xsi:type': 'Bar' } ],
     [ 'closeTag', 'ns0:bar' ],
     [ 'closeTag', 'ns0:foo' ],
   ],

--- a/test/modes.js
+++ b/test/modes.js
@@ -34,9 +34,7 @@ describe('modes', function() {
           'ns': 'ns',
           'ns$uri': 'http://ns',
           'xmlns': 'ns',
-          'xmlns$uri': 'http://ns',
-          'xsi': 'xsi',
-          'xsi$uri': 'http://www.w3.org/2001/XMLSchema-instance'
+          'xmlns$uri': 'http://ns'
         });
 
         assert.equal(decodeEntities(el.attrs.foo), '"');
@@ -78,9 +76,7 @@ describe('modes', function() {
           'ns': 'ns',
           'ns$uri': 'http://ns',
           'xmlns': 'ns',
-          'xmlns$uri': 'http://ns',
-          'xsi': 'xsi',
-          'xsi$uri': 'http://www.w3.org/2001/XMLSchema-instance'
+          'xmlns$uri': 'http://ns'
         });
       });
 


### PR DESCRIPTION
Off-loads the `xsi:type` attribute and attribute value manipulation magic to downstream implementors. They have all the tools in place to perform the necessary changes.
 
* Do not map values inside `xsi:type` attribute.
* Do not force `xsi` prefix for `XMLSchemaInstance`

Off-loading to downstream implementors allows us to stay minimal (do one thing and do it right), but also give more power to downstream implementors to properly READ and WRITE XML.

----

This is a breaking change, to be shipped with a new major version.